### PR TITLE
Add functionality to provide granular API access control

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -6,11 +6,18 @@ import no.nav.syfo.util.getFileAsString
 data class Environment(
     val aadAppClient: String = getEnvVar("AZURE_APP_CLIENT_ID"),
     val azureAppWellKnownUrl: String = getEnvVar("AZURE_APP_WELL_KNOWN_URL"),
+    val azureAppPreAuthorizedApps: String = getEnvVar("AZURE_APP_PRE_AUTHORIZED_APP"),
     val serviceuserUsername: String = getFileAsString("/secrets/serviceuser/isproxy/username"),
     val serviceuserPassword: String = getFileAsString("/secrets/serviceuser/isproxy/password"),
     val eregUrl: String = getEnvVar("EREG_URL"),
     val stsUrl: String = getEnvVar("SECURITY_TOKEN_SERVICE_URL"),
     val dokdistUrl: String = getEnvVar("DOKDIST_URL"),
+
+    val isdialogmoteApplicationName: String = "isdialogmote",
+    val isnarmestelederApplicationName: String = "isnarmesteleder",
+    val eregAPIAuthorizedConsumerApplicationNameList: List<String> = listOf(
+        isnarmestelederApplicationName,
+    )
 )
 
 fun getEnvVar(varName: String, defaultValue: String? = null) =

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -5,6 +5,7 @@ import io.ktor.auth.*
 import io.ktor.routing.*
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.Environment
+import no.nav.syfo.application.api.access.APIConsumerAccessService
 import no.nav.syfo.application.api.authentication.*
 import no.nav.syfo.client.dokdist.DokdistClient
 import no.nav.syfo.client.sts.StsClient
@@ -45,6 +46,10 @@ fun Application.apiModule(
         stsClient = stsClient,
     )
 
+    val apiConsumerAccessService = APIConsumerAccessService(
+        azureAppPreAuthorizedApps = environment.azureAppPreAuthorizedApps,
+    )
+
     routing {
         registerPodApi(applicationState)
         registerPrometheusApi()
@@ -54,6 +59,8 @@ fun Application.apiModule(
                 dokdistClient = dokdistClient
             )
             registerEregProxyApi(
+                apiConsumerAccessService = apiConsumerAccessService,
+                authorizedApplicationNameList = environment.eregAPIAuthorizedConsumerApplicationNameList,
                 eregClient = eregClient,
             )
         }

--- a/src/main/kotlin/no/nav/syfo/application/api/access/APIConsumerAccessService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/access/APIConsumerAccessService.kt
@@ -1,0 +1,38 @@
+package no.nav.syfo.application.api.access
+
+import com.auth0.jwt.JWT
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.syfo.util.configuredJacksonMapper
+
+const val JWT_CLAIM_AZP = "azp"
+
+fun getConsumerClientId(token: String): String? {
+    val decodedJWT = JWT.decode(token)
+    return decodedJWT.claims[JWT_CLAIM_AZP]?.asString()
+}
+
+class APIConsumerAccessService(
+    azureAppPreAuthorizedApps: String
+) {
+    private val preAuthorizedClientList: List<PreAuthorizedClient> = configuredJacksonMapper()
+        .readValue(azureAppPreAuthorizedApps)
+
+    fun validateConsumerApplicationAZP(
+        authorizedApplicationNameList: List<String>,
+        token: String,
+    ) {
+        val clientIdList = preAuthorizedClientList
+            .filter {
+                authorizedApplicationNameList.contains(
+                    it.toNamespaceAndApplicationName().applicationName
+                )
+            }
+            .map { it.clientId }
+
+        val consumerClientIdAzp = getConsumerClientId(token = token)
+            ?: throw IllegalArgumentException("Claim AZP was not found in token")
+        if (!clientIdList.contains(consumerClientIdAzp)) {
+            throw ForbiddenProxyConsumer(consumerClientIdAzp = consumerClientIdAzp)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/application/api/access/ForbiddenProxyConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/access/ForbiddenProxyConsumer.kt
@@ -1,0 +1,6 @@
+package no.nav.syfo.application.api.access
+
+class ForbiddenProxyConsumer(
+    consumerClientIdAzp: String,
+    message: String = "Consumer with clientId(azp)=$consumerClientIdAzp is denied access to system API",
+) : RuntimeException(message)

--- a/src/main/kotlin/no/nav/syfo/application/api/access/PreAuthorizedApplication.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/access/PreAuthorizedApplication.kt
@@ -1,0 +1,19 @@
+package no.nav.syfo.application.api.access
+
+data class PreAuthorizedClient(
+    val name: String,
+    val clientId: String,
+)
+
+fun PreAuthorizedClient.toNamespaceAndApplicationName(): NamespaceAndApplicationName {
+    val split = name.split(":")
+    return NamespaceAndApplicationName(
+        namespace = split[1],
+        applicationName = split[2]
+    )
+}
+
+data class NamespaceAndApplicationName(
+    val namespace: String,
+    val applicationName: String,
+)

--- a/src/main/kotlin/no/nav/syfo/ereg/api/EregProxyApi.kt
+++ b/src/main/kotlin/no/nav/syfo/ereg/api/EregProxyApi.kt
@@ -3,15 +3,17 @@ package no.nav.syfo.ereg.api
 import io.ktor.application.*
 import io.ktor.response.*
 import io.ktor.routing.*
+import no.nav.syfo.application.api.access.APIConsumerAccessService
 import no.nav.syfo.ereg.client.EregClient
-import no.nav.syfo.util.getCallId
-import no.nav.syfo.util.handleProxyError
+import no.nav.syfo.util.*
 
 const val eregProxyBasePath = "/api/v1/ereg"
 const val eregProxyOrganisasjonPath = "/organisasjon"
 const val eregOrgnrParam = "orgnr"
 
 fun Route.registerEregProxyApi(
+    apiConsumerAccessService: APIConsumerAccessService,
+    authorizedApplicationNameList: List<String>,
     eregClient: EregClient,
 ) {
     route(eregProxyBasePath) {
@@ -20,6 +22,14 @@ fun Route.registerEregProxyApi(
             try {
                 val eregOrgnr = call.parameters[eregOrgnrParam]
                     ?: throw IllegalArgumentException("No Orgnr found in path param")
+
+                val token = getBearerHeader()
+                    ?: throw IllegalArgumentException("No Authorization header supplied")
+
+                apiConsumerAccessService.validateConsumerApplicationAZP(
+                    authorizedApplicationNameList = authorizedApplicationNameList,
+                    token = token,
+                )
 
                 val eregOrganisasjonResponse = eregClient.organisasjon(
                     callId = callId,

--- a/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
@@ -6,6 +6,7 @@ import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.util.pipeline.*
 import net.logstash.logback.argument.StructuredArguments
+import no.nav.syfo.application.api.access.ForbiddenProxyConsumer
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.*
@@ -17,6 +18,10 @@ const val NAV_CONSUMER_TOKEN_HEADER = "Nav-Consumer-Token"
 
 fun PipelineContext<out Unit, ApplicationCall>.getCallId(): String {
     return this.call.request.headers[NAV_CALL_ID_HEADER].toString()
+}
+
+fun PipelineContext<out Unit, ApplicationCall>.getBearerHeader(): String? {
+    return this.call.request.headers[HttpHeaders.Authorization]?.removePrefix("Bearer ")
 }
 
 fun bearerHeader(token: String) = "Bearer $token"
@@ -41,6 +46,9 @@ suspend fun PipelineContext<out Unit, ApplicationCall>.handleProxyError(
         }
         is IllegalArgumentException -> {
             HttpStatusCode.BadRequest
+        }
+        is ForbiddenProxyConsumer -> {
+            HttpStatusCode.Forbidden
         }
         else -> {
             HttpStatusCode.InternalServerError

--- a/src/test/kotlin/no/nav/syfo/api/DistribuerJournalpostApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/api/DistribuerJournalpostApiSpek.kt
@@ -43,6 +43,7 @@ class DistribuerJournalpostApiSpek : Spek({
                 val validToken = generateJWT(
                     externalMockEnvironment.environment.aadAppClient,
                     externalMockEnvironment.wellKnown.issuer,
+                    externalMockEnvironment.environment.isdialogmoteApplicationName,
                 )
                 val dokdistRequest = DokdistRequest(
                     journalpostId = "jpid",

--- a/src/test/kotlin/no/nav/syfo/ereg/api/EregProxyApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/ereg/api/EregProxyApiSpek.kt
@@ -41,6 +41,7 @@ class EregProxyApiSpek : Spek({
                 val validToken = generateJWT(
                     externalMockEnvironment.environment.aadAppClient,
                     externalMockEnvironment.wellKnown.issuer,
+                    testIsnarmestelederClientId,
                 )
 
                 describe("Happy path") {
@@ -63,6 +64,22 @@ class EregProxyApiSpek : Spek({
                             handleRequest(HttpMethod.Get, urlEregOrganisasjonWithParam) {}
                         ) {
                             response.status() shouldBeEqualTo HttpStatusCode.Unauthorized
+                        }
+                    }
+
+                    it("should return status Forbidden if unauthorized AZP is supplied") {
+                        val validTokenUnauthorizedAZP = generateJWT(
+                            externalMockEnvironment.environment.aadAppClient,
+                            externalMockEnvironment.wellKnown.issuer,
+                            testIsdialogmoteClientId,
+                        )
+
+                        with(
+                            handleRequest(HttpMethod.Get, urlEregOrganisasjonWithParam) {
+                                addHeader(Authorization, bearerHeader(validTokenUnauthorizedAZP))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.Forbidden
                         }
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/JWTUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/JWTUtils.kt
@@ -4,6 +4,7 @@ import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jose.jwk.RSAKey
+import no.nav.syfo.application.api.access.JWT_CLAIM_AZP
 import no.nav.syfo.application.api.authentication.JWT_CLAIM_NAVIDENT
 import java.io.IOException
 import java.nio.charset.StandardCharsets
@@ -21,6 +22,7 @@ const val keyId = "localhost-signer"
 fun generateJWT(
     audience: String,
     issuer: String,
+    azp: String,
     navIdent: String? = null,
     subject: String? = null,
     expiry: LocalDateTime? = LocalDateTime.now().plusHours(1)
@@ -41,6 +43,7 @@ fun generateJWT(
         .withClaim("nbf", now)
         .withClaim("iat", now)
         .withClaim("exp", Date.from(expiry?.atZone(ZoneId.systemDefault())?.toInstant()))
+        .withClaim(JWT_CLAIM_AZP, azp)
         .withClaim(JWT_CLAIM_NAVIDENT, navIdent)
         .sign(alg)
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -2,6 +2,8 @@ package no.nav.syfo.testhelper
 
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.Environment
+import no.nav.syfo.application.api.access.PreAuthorizedClient
+import no.nav.syfo.util.configuredJacksonMapper
 import java.net.ServerSocket
 
 fun testEnvironment(
@@ -11,6 +13,7 @@ fun testEnvironment(
 ) = Environment(
     aadAppClient = "isproxy-client-id",
     azureAppWellKnownUrl = "wellknown",
+    azureAppPreAuthorizedApps = configuredJacksonMapper().writeValueAsString(testAzureAppPreAuthorizedApps),
     serviceuserUsername = "user",
     serviceuserPassword = "password",
     eregUrl = eregUrl,
@@ -26,3 +29,17 @@ fun testAppState() = ApplicationState(
 fun getRandomPort() = ServerSocket(0).use {
     it.localPort
 }
+
+const val testIsdialogmoteClientId = "isdialogmote-client-id"
+const val testIsnarmestelederClientId = "isnarmesteleder-client-id"
+
+val testAzureAppPreAuthorizedApps = listOf(
+    PreAuthorizedClient(
+        name = "dev-gcp:teamsykefravr:isdialogmote",
+        clientId = testIsdialogmoteClientId,
+    ),
+    PreAuthorizedClient(
+        name = "dev-gcp:teamsykefravr:isnarmesteleder",
+        clientId = testIsnarmestelederClientId,
+    ),
+)


### PR DESCRIPTION
Azurerator provides access control to the whole application, but we need a more granular access control to control which consumer is allowed to use each API. The acces control is performed by white listing a list of AZP-consumers for each API.