### PR TITLE
Fastlege-api via isproxy

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -73,3 +73,8 @@ spec:
       value: "https://dokdistfordeling-q1.nais.preprod.local"
     - name: SYFOSYKETILFELLE_URL
       value: "https://syfosyketilfelle.nais.preprod.local"
+    - name: FASTLEGE_URL
+      value: "https://pep-gw-q4.oera-q.local:9443/ekstern/helse/fastlegeinformasjon"
+    - name: ADRESSEREGISTER_URL
+      value: "https://pep-gw-q4.oera-q.local:9443/ekstern/helse/adresseregisteret/v1"
+

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -73,3 +73,8 @@ spec:
       value: "https://dokdistfordeling.nais.adeo.no"
     - name: SYFOSYKETILFELLE_URL
       value: "https://syfosyketilfelle.nais.adeo.no"
+    - name: FASTLEGE_URL
+      value: "https://pep-gw.oera.no:9443/ekstern/helse/fastlegeinformasjon"
+    - name: ADRESSEREGISTER_URL
+      value: "https://pep-gw.oera.no:9443/ekstern/helse/adresseregisteret/v1"
+

--- a/README.md
+++ b/README.md
@@ -25,6 +25,44 @@ Run checking: `./gradlew --continue ktlintCheck`
 
 Run formatting: `./gradlew ktlintFormat`
 
+## Download packages from Github Package Registry
+
+Certain packages (tjenestespesifikasjoner) must be downloaded from Github Package Registry, which requires
+authentication. The packages can be downloaded via build.gradle:
+
+```
+val githubUser: String by project
+val githubPassword: String by project
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/navikt/tjenestespesifikasjoner")
+        credentials {
+            username = githubUser
+            password = githubPassword
+        }
+    }
+}
+```
+
+`githubUser` and `githubPassword` are properties that are set in `~/.gradle/gradle.properties`:
+
+```
+githubUser=x-access-token
+githubPassword=<token>
+```
+
+Where `<token>` is a personal access token with scope `read:packages`(and SSO enabled).
+
+The variables can alternatively be configured as environment variables or used in the command lines:
+
+* `ORG_GRADLE_PROJECT_githubUser`
+* `ORG_GRADLE_PROJECT_githubPassword`
+
+```
+./gradlew -PgithubUser=x-access-token -PgithubPassword=[token]
+```
+
+
 ### Contact us
 
 Code/project related questions? Slack --> #isyfo

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,12 +10,17 @@ object Versions {
     const val ktorVersion = "1.6.3"
     const val jaxbVersion = "2.3.1"
     const val kluentVersion = "1.68"
+    const val cxfVersion = "3.3.9"
+    const val javaxActivationVersion = "1.2.0"
+    const val javaxWsRsApiVersion = "2.1.1"
+    const val jaxwsVersion = "2.3.5"
     const val logbackVersion = "1.2.3"
     const val logstashEncoderVersion = "6.3"
     const val mockkVersion = "1.10.5"
     const val nimbusjosejwtVersion = "7.5.1"
     const val spekVersion = "2.0.15"
     const val micrometerRegistryVersion = "1.7.1"
+    const val syfotjenesterVersion = "1.2021.06.09-13.09-b3d30de9996e"
 }
 
 plugins {
@@ -24,10 +29,19 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "10.1.0"
 }
 
+val githubUser: String by project
+val githubPassword: String by project
 repositories {
     mavenCentral()
     maven(url = "https://packages.confluent.io/maven/")
     maven(url = "https://jitpack.io")
+    maven {
+        url = uri("https://maven.pkg.github.com/navikt/tjenestespesifikasjoner")
+        credentials {
+            username = githubUser
+            password = githubPassword
+        }
+    }
 }
 
 dependencies {
@@ -40,6 +54,19 @@ dependencies {
     implementation("io.ktor:ktor-client-jackson:${Versions.ktorVersion}")
     implementation("io.ktor:ktor-jackson:${Versions.ktorVersion}")
     implementation("io.ktor:ktor-server-netty:${Versions.ktorVersion}")
+
+    implementation("org.apache.cxf:cxf-rt-features-logging:${Versions.cxfVersion}")
+    implementation("org.apache.cxf:cxf-rt-ws-security:${Versions.cxfVersion}")
+    implementation("org.apache.cxf:cxf-rt-ws-policy:${Versions.cxfVersion}")
+    implementation("org.apache.cxf:cxf-rt-transports-http:${Versions.cxfVersion}")
+    implementation("org.apache.cxf:cxf-rt-frontend-jaxws:${Versions.cxfVersion}")
+    implementation("javax.ws.rs:javax.ws.rs-api:${Versions.javaxWsRsApiVersion}")
+    implementation("com.sun.xml.ws:jaxws-ri:${Versions.jaxwsVersion}")
+    implementation("com.sun.xml.ws:jaxws-tools:${Versions.jaxwsVersion}")
+    implementation("com.sun.activation:javax.activation:${Versions.javaxActivationVersion}")
+
+    implementation("no.nav.syfotjenester:adresseregisteretv1-tjenestespesifikasjon:${Versions.syfotjenesterVersion}")
+    implementation("no.nav.syfotjenester:fastlegeinformasjonv1-tjenestespesifikasjon:${Versions.syfotjenesterVersion}")
 
     implementation("ch.qos.logback:logback-classic:${Versions.logbackVersion}")
     implementation("net.logstash.logback:logstash-logback-encoder:${Versions.logstashEncoderVersion}")

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -12,15 +12,24 @@ data class Environment(
     val eregUrl: String = getEnvVar("EREG_URL"),
     val stsUrl: String = getEnvVar("SECURITY_TOKEN_SERVICE_URL"),
     val dokdistUrl: String = getEnvVar("DOKDIST_URL"),
+    val fastlegeUrl: String = getEnvVar("FASTLEGE_URL"),
+    val adresseregisterUrl: String = getEnvVar("ADRESSEREGISTER_URL"),
     val syfosyketilfelleUrl: String = getEnvVar("SYFOSYKETILFELLE_URL"),
 
     val isdialogmoteApplicationName: String = "isdialogmote",
     val isnarmestelederApplicationName: String = "isnarmesteleder",
+    val fastlegerestApplicationName: String = "fastlegerest",
     val eregAPIAuthorizedConsumerApplicationNameList: List<String> = listOf(
         isnarmestelederApplicationName,
     ),
     val dokdistAPIAuthorizedConsumerApplicationNameList: List<String> = listOf(
         isdialogmoteApplicationName,
+    ),
+    val fastlegeAPIAuthorizedConsumerApplicationNameList: List<String> = listOf(
+        fastlegerestApplicationName,
+    ),
+    val fastlegepraksisAPIAuthorizedConsumerApplicationNameList: List<String> = listOf(
+        fastlegerestApplicationName,
     ),
     val syfosyketilfelleAPIAuthorizedConsumerApplicationNameList: List<String> = listOf(
         isdialogmoteApplicationName,

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -9,9 +9,16 @@ import no.nav.syfo.application.api.access.APIConsumerAccessService
 import no.nav.syfo.application.api.authentication.*
 import no.nav.syfo.dokdist.client.DokdistClient
 import no.nav.syfo.client.sts.StsClient
+import no.nav.syfo.client.StsClientProperties
+import no.nav.syfo.fastlege.ws.adresseregister.AdresseregisterClient
+import no.nav.syfo.fastlege.ws.adresseregister.adresseregisterSoapClient
 import no.nav.syfo.dokdist.api.registerDokdistApi
+import no.nav.syfo.fastlege.ws.fastlege.FastlegeInformasjonClient
+import no.nav.syfo.fastlege.ws.fastlege.fastlegeSoapClient
+import no.nav.syfo.fastlege.api.registerFastlegeApi
 import no.nav.syfo.ereg.api.registerEregProxyApi
 import no.nav.syfo.ereg.client.EregClient
+import no.nav.syfo.fastlege.api.registerFastlegepraksisApi
 import no.nav.syfo.syfosyketilfelle.api.registerSyfosyketilfelleApi
 import no.nav.syfo.syfosyketilfelle.client.SyfosyketilfelleClient
 
@@ -34,12 +41,14 @@ fun Application.apiModule(
         ),
     )
 
-    val stsClient = StsClient(
+    val stsClientProperties = StsClientProperties(
         baseUrl = environment.stsUrl,
         serviceuserUsername = environment.serviceuserUsername,
         serviceuserPassword = environment.serviceuserPassword,
     )
-
+    val stsClient = StsClient(
+        properties = stsClientProperties,
+    )
     val dokdistClient = DokdistClient(
         dokdistBaseUrl = environment.dokdistUrl,
         stsClient = stsClient,
@@ -51,6 +60,18 @@ fun Application.apiModule(
     val syfosyketilfelleClient = SyfosyketilfelleClient(
         baseUrl = environment.syfosyketilfelleUrl,
         stsClient = stsClient,
+    )
+    val fastlegeInformasjonClient = FastlegeInformasjonClient(
+        fastlegeSoapClient = fastlegeSoapClient(
+            serviceUrl = environment.fastlegeUrl,
+            stsProperties = stsClientProperties,
+        )
+    )
+    val adresseregisterClient = AdresseregisterClient(
+        adresseregisterSoapClient = adresseregisterSoapClient(
+            serviceUrl = environment.adresseregisterUrl,
+            stsProperties = stsClientProperties,
+        )
     )
 
     val apiConsumerAccessService = APIConsumerAccessService(
@@ -66,6 +87,16 @@ fun Application.apiModule(
                 apiConsumerAccessService = apiConsumerAccessService,
                 authorizedApplicationNameList = environment.dokdistAPIAuthorizedConsumerApplicationNameList,
                 dokdistClient = dokdistClient,
+            )
+            registerFastlegeApi(
+                apiConsumerAccessService = apiConsumerAccessService,
+                authorizedApplicationNameList = environment.fastlegeAPIAuthorizedConsumerApplicationNameList,
+                fastlegeClient = fastlegeInformasjonClient,
+            )
+            registerFastlegepraksisApi(
+                apiConsumerAccessService = apiConsumerAccessService,
+                authorizedApplicationNameList = environment.fastlegepraksisAPIAuthorizedConsumerApplicationNameList,
+                adresseregisterClient = adresseregisterClient,
             )
             registerEregProxyApi(
                 apiConsumerAccessService = apiConsumerAccessService,

--- a/src/main/kotlin/no/nav/syfo/client/StsClientProperties.kt
+++ b/src/main/kotlin/no/nav/syfo/client/StsClientProperties.kt
@@ -1,0 +1,7 @@
+package no.nav.syfo.client
+
+data class StsClientProperties(
+    val baseUrl: String,
+    val serviceuserUsername: String,
+    val serviceuserPassword: String,
+)

--- a/src/main/kotlin/no/nav/syfo/fastlege/api/FastlegeAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/api/FastlegeAPI.kt
@@ -1,0 +1,33 @@
+package no.nav.syfo.fastlege.api
+
+import io.ktor.application.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import no.nav.syfo.application.api.access.APIConsumerAccessService
+import no.nav.syfo.fastlege.ws.fastlege.FastlegeInformasjonClient
+import no.nav.syfo.util.*
+
+const val fastlegeBasePath = "/api/v1/fastlege"
+
+fun Route.registerFastlegeApi(
+    apiConsumerAccessService: APIConsumerAccessService,
+    authorizedApplicationNameList: List<String>,
+    fastlegeClient: FastlegeInformasjonClient,
+) {
+    route(fastlegeBasePath) {
+        get() {
+            proxyRequestHandler(
+                apiConsumerAccessService = apiConsumerAccessService,
+                authorizedApplicationNameList = authorizedApplicationNameList,
+                proxyServiceName = "Fastlege",
+            ) {
+                val fnr = getHeader(NAV_PERSONIDENT_HEADER)
+                    ?: throw IllegalArgumentException("No fnr given")
+
+                val fastleger = fastlegeClient.hentBrukersFastleger(fnr)
+
+                call.respond(fastleger)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/fastlege/api/FastlegepraksisAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/api/FastlegepraksisAPI.kt
@@ -1,0 +1,34 @@
+package no.nav.syfo.fastlege.api
+
+import io.ktor.application.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import no.nav.syfo.application.api.access.APIConsumerAccessService
+import no.nav.syfo.fastlege.ws.adresseregister.AdresseregisterClient
+import no.nav.syfo.util.*
+
+const val fastlegepraksisBasePath = "/api/v1/fastlegepraksis"
+const val herid = "herid"
+
+fun Route.registerFastlegepraksisApi(
+    apiConsumerAccessService: APIConsumerAccessService,
+    authorizedApplicationNameList: List<String>,
+    adresseregisterClient: AdresseregisterClient,
+) {
+    route(fastlegepraksisBasePath) {
+        get("/{$herid}") {
+            proxyRequestHandler(
+                apiConsumerAccessService = apiConsumerAccessService,
+                authorizedApplicationNameList = authorizedApplicationNameList,
+                proxyServiceName = "Fastlegepraksis",
+            ) {
+                val herid = call.parameters[herid]?.toInt()
+                    ?: throw IllegalArgumentException("No herId found in path param")
+
+                val praksisInfo = adresseregisterClient.hentPraksisInfoForFastlege(herid)
+
+                call.respond(praksisInfo)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/fastlege/ws/adresseregister/AdresseregisterClient.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/ws/adresseregister/AdresseregisterClient.kt
@@ -1,0 +1,36 @@
+package no.nav.syfo.fastlege.ws.adresseregister
+
+import no.nhn.register.communicationparty.ICommunicationPartyService
+import no.nhn.register.communicationparty.ICommunicationPartyServiceGetOrganizationPersonDetailsGenericFaultFaultFaultMessage
+import org.slf4j.LoggerFactory
+
+class AdresseregisterClient(
+    private val adresseregisterSoapClient: ICommunicationPartyService
+) {
+    fun hentPraksisInfoForFastlege(herId: Int): PraksisInfo {
+        return try {
+            val wsOrganizationPerson = adresseregisterSoapClient.getOrganizationPersonDetails(herId)
+            PraksisInfo(
+                foreldreEnhetHerId = wsOrganizationPerson.parentHerId
+            )
+        } catch (e: ICommunicationPartyServiceGetOrganizationPersonDetailsGenericFaultFaultFaultMessage) {
+            log.error(
+                "Søkte opp fastlege med HerId {} og fikk en feil fra adresseregister fordi fastlegen mangler HerId",
+                herId,
+                e
+            )
+            throw PraksisInfoIkkeFunnet("Fant ikke parentHerId for fastlege med HerId $herId")
+        } catch (e: RuntimeException) {
+            log.error(
+                "Søkte opp fastlege med HerId {} og fikk en uventet feil fra adresseregister fordi tjenesten er nede",
+                herId,
+                e
+            )
+            throw e
+        }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(AdresseregisterClient::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/fastlege/ws/adresseregister/AdresseregisterConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/ws/adresseregister/AdresseregisterConfig.kt
@@ -1,0 +1,21 @@
+package no.nav.syfo.fastlege.ws.adresseregister
+
+import no.nav.syfo.client.StsClientProperties
+import no.nav.syfo.fastlege.ws.util.*
+import no.nhn.register.communicationparty.ICommunicationPartyService
+
+fun adresseregisterSoapClient(
+    serviceUrl: String,
+    stsProperties: StsClientProperties,
+): ICommunicationPartyService {
+    val port = WsClient<ICommunicationPartyService>().createPort(
+        serviceUrl = serviceUrl,
+        portType = ICommunicationPartyService::class.java,
+        handlers = listOf(LogErrorHandler())
+    )
+    configureRequestSamlToken(
+        port = port,
+        stsProperties = stsProperties,
+    )
+    return port
+}

--- a/src/main/kotlin/no/nav/syfo/fastlege/ws/adresseregister/PraksisInfo.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/ws/adresseregister/PraksisInfo.kt
@@ -1,0 +1,5 @@
+package no.nav.syfo.fastlege.ws.adresseregister
+
+data class PraksisInfo(
+    val foreldreEnhetHerId: Int? = null
+)

--- a/src/main/kotlin/no/nav/syfo/fastlege/ws/adresseregister/PraksisInfoIkkeFunnet.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/ws/adresseregister/PraksisInfoIkkeFunnet.kt
@@ -1,0 +1,3 @@
+package no.nav.syfo.fastlege.ws.adresseregister
+
+class PraksisInfoIkkeFunnet(message: String) : RuntimeException(message)

--- a/src/main/kotlin/no/nav/syfo/fastlege/ws/fastlege/FastlegeIkkeFunnet.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/ws/fastlege/FastlegeIkkeFunnet.kt
@@ -1,0 +1,3 @@
+package no.nav.syfo.fastlege.ws.fastlege
+
+class FastlegeIkkeFunnet(message: String) : RuntimeException(message)

--- a/src/main/kotlin/no/nav/syfo/fastlege/ws/fastlege/FastlegeInformasjonClient.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/ws/fastlege/FastlegeInformasjonClient.kt
@@ -1,0 +1,94 @@
+package no.nav.syfo.fastlege.ws.fastlege
+
+import no.nav.syfo.fastlege.ws.fastlege.model.*
+import no.nhn.schemas.reg.common.en.WSPeriod
+import no.nhn.schemas.reg.flr.*
+import org.slf4j.LoggerFactory
+import java.time.LocalDate
+
+class FastlegeInformasjonClient(
+    val fastlegeSoapClient: IFlrReadOperations,
+) {
+    fun hentBrukersFastleger(brukersFnr: String): List<Fastlege> {
+        return try {
+            val patientGPDetails: WSPatientToGPContractAssociation = fastlegeSoapClient.getPatientGPDetails(brukersFnr)
+            hentFastleger(patientGPDetails)
+        } catch (e: IFlrReadOperationsGetPatientGPDetailsGenericFaultFaultFaultMessage) {
+            log.warn("Søkte opp og fikk en feil fra fastlegetjenesten. Dette skjer trolig fordi FNRet ikke finnes", e)
+            throw FastlegeIkkeFunnet("Feil ved oppslag av fastlege")
+        } catch (e: RuntimeException) {
+            log.error("Søkte opp og fikk en feil fra fastlegetjenesten fordi tjenesten er nede", e)
+            throw e
+        }
+    }
+
+    private fun hentFastleger(patientGPDetails: WSPatientToGPContractAssociation): List<Fastlege> {
+        return patientGPDetails.doctorCycles.gpOnContractAssociations
+            .map { wsgPOnContractAssociation ->
+                Fastlege(
+                    fornavn = wsgPOnContractAssociation.gp.firstName,
+                    mellomnavn = wsgPOnContractAssociation.gp.middleName,
+                    etternavn = wsgPOnContractAssociation.gp.lastName,
+                    fnr = wsgPOnContractAssociation.gp.nin,
+                    herId = patientGPDetails.gpHerId,
+                    helsepersonellregisterId = wsgPOnContractAssociation.hprNumber.toString(),
+                    fastlegekontor = getFastlegekontor(patientGPDetails.gpContract.gpOffice),
+                    pasientforhold = getPasientForhold(patientGPDetails.period),
+                )
+            }
+    }
+
+    private fun getPasientForhold(period: WSPeriod): Pasientforhold {
+        return Pasientforhold(
+            fom = period.from.toLocalDate(),
+            tom = if (period.to == null) LocalDate.parse("9999-12-31") else period.to.toLocalDate()
+        )
+    }
+
+    private fun getFastlegekontor(wsgpOffice: WSGPOffice): Fastlegekontor {
+        return Fastlegekontor(
+            navn = wsgpOffice.name,
+            orgnummer = wsgpOffice.organizationNumber?.toString(),
+            telefon = extractElectronicAddressField(wsgpOffice, "E_TLF"),
+            epost = extractElectronicAddressField(wsgpOffice, "E_EDI"),
+            postadresse = extractPhysicalAddress(wsgpOffice, "PST"),
+            besoeksadresse = extractPhysicalAddress(wsgpOffice, "RES"),
+        )
+    }
+
+    private fun extractPhysicalAddress(wsgpOffice: WSGPOffice, field: String) =
+        wsgpOffice.physicalAddresses.physicalAddresses.stream()
+            .filter { wsPhysicalAddress ->
+                wsPhysicalAddress.type != null &&
+                    wsPhysicalAddress.type.isActive &&
+                    wsPhysicalAddress.type.codeValue == field
+            }
+            .findFirst()
+            .map { wsPhysicalAddress ->
+                Adresse(
+                    adresse = wsPhysicalAddress.postbox,
+                    postnummer = postnummer(wsPhysicalAddress.postalCode),
+                    poststed = wsPhysicalAddress.city,
+                )
+            }
+            .orElse(null)
+
+    private fun extractElectronicAddressField(wsgpOffice: WSGPOffice, field: String) =
+        wsgpOffice.electronicAddresses.electronicAddresses.stream()
+            .filter { it.type.codeValue == field }
+            .findFirst()
+            .map { it.address }
+            .orElse("")
+
+    private fun postnummer(postalCode: Int): String {
+        val postnummer = StringBuilder(postalCode.toString())
+        while (postnummer.length < 4) {
+            postnummer.insert(0, "0")
+        }
+        return postnummer.toString()
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(FastlegeInformasjonClient::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/fastlege/ws/fastlege/FastlegeInformasjonConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/ws/fastlege/FastlegeInformasjonConfig.kt
@@ -1,0 +1,21 @@
+package no.nav.syfo.fastlege.ws.fastlege
+
+import no.nav.syfo.client.StsClientProperties
+import no.nav.syfo.fastlege.ws.util.*
+import no.nhn.schemas.reg.flr.IFlrReadOperations
+
+fun fastlegeSoapClient(
+    serviceUrl: String,
+    stsProperties: StsClientProperties,
+): IFlrReadOperations {
+    val port = WsClient<IFlrReadOperations>().createPort(
+        serviceUrl = serviceUrl,
+        portType = IFlrReadOperations::class.java,
+        handlers = listOf(LogErrorHandler())
+    )
+    configureRequestSamlToken(
+        port = port,
+        stsProperties = stsProperties,
+    )
+    return port
+}

--- a/src/main/kotlin/no/nav/syfo/fastlege/ws/fastlege/model/Adresse.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/ws/fastlege/model/Adresse.kt
@@ -1,0 +1,7 @@
+package no.nav.syfo.fastlege.ws.fastlege.model
+
+data class Adresse(
+    val adresse: String,
+    val postnummer: String,
+    val poststed: String,
+)

--- a/src/main/kotlin/no/nav/syfo/fastlege/ws/fastlege/model/Fastlege.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/ws/fastlege/model/Fastlege.kt
@@ -1,0 +1,12 @@
+package no.nav.syfo.fastlege.ws.fastlege.model
+
+data class Fastlege(
+    val fornavn: String,
+    val mellomnavn: String,
+    val etternavn: String,
+    val fnr: String,
+    val herId: Int,
+    val helsepersonellregisterId: String,
+    val fastlegekontor: Fastlegekontor,
+    val pasientforhold: Pasientforhold,
+)

--- a/src/main/kotlin/no/nav/syfo/fastlege/ws/fastlege/model/Fastlegekontor.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/ws/fastlege/model/Fastlegekontor.kt
@@ -1,0 +1,10 @@
+package no.nav.syfo.fastlege.ws.fastlege.model
+
+data class Fastlegekontor(
+    val navn: String,
+    val besoeksadresse: Adresse,
+    val postadresse: Adresse,
+    val telefon: String,
+    val epost: String,
+    val orgnummer: String?,
+)

--- a/src/main/kotlin/no/nav/syfo/fastlege/ws/fastlege/model/Pasient.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/ws/fastlege/model/Pasient.kt
@@ -1,0 +1,5 @@
+package no.nav.syfo.fastlege.ws.fastlege.model
+
+data class Pasient(
+    val fnr: String,
+)

--- a/src/main/kotlin/no/nav/syfo/fastlege/ws/fastlege/model/Pasientforhold.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/ws/fastlege/model/Pasientforhold.kt
@@ -1,0 +1,8 @@
+package no.nav.syfo.fastlege.ws.fastlege.model
+
+import java.time.LocalDate
+
+data class Pasientforhold(
+    val fom: LocalDate,
+    val tom: LocalDate,
+)

--- a/src/main/kotlin/no/nav/syfo/fastlege/ws/util/LogErrorHandler.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/ws/util/LogErrorHandler.kt
@@ -1,0 +1,59 @@
+package no.nav.syfo.fastlege.ws.util
+
+import org.apache.cxf.interceptor.Fault
+import org.apache.cxf.jaxws.handler.soap.SOAPMessageContextImpl
+import org.apache.cxf.message.Message
+import org.apache.cxf.service.Service
+import org.apache.cxf.service.model.OperationInfo
+import org.slf4j.LoggerFactory
+import javax.xml.namespace.QName
+import javax.xml.ws.handler.MessageContext
+import javax.xml.ws.handler.soap.SOAPHandler
+import javax.xml.ws.handler.soap.SOAPMessageContext
+
+class LogErrorHandler : SOAPHandler<SOAPMessageContext> {
+    override fun getHeaders(): Set<QName>? {
+        return null
+    }
+
+    override fun handleMessage(context: SOAPMessageContext): Boolean {
+        return true
+    }
+
+    override fun handleFault(context: SOAPMessageContext): Boolean {
+        if (context is SOAPMessageContextImpl) {
+            val message = context.wrappedMessage
+            var exception: Throwable? = message.getContent(Exception::class.java)
+            if (exception is Fault && exception.cause != null) {
+                exception = exception.cause!!
+            }
+            LOG.warn(beskrivelse(message).toString(), exception)
+        }
+        return true
+    }
+
+    private fun beskrivelse(message: Message): StringBuilder {
+        val beskrivelse = StringBuilder()
+        beskrivelse.append("Det oppstod en feil i WS-kallet")
+        if (message.exchange != null) {
+            val exchange = message.exchange
+            val service = exchange.get(Service::class.java)
+            if (service != null) {
+                beskrivelse.append(" \'")
+                beskrivelse.append(service.name)
+                val opInfo = exchange.get(OperationInfo::class.java)
+                if (opInfo != null) {
+                    beskrivelse.append("#").append(opInfo.name)
+                }
+                beskrivelse.append('\'')
+            }
+        }
+        return beskrivelse.append(":")
+    }
+
+    override fun close(context: MessageContext) {}
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(LogErrorHandler::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/fastlege/ws/util/STSClientConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/ws/util/STSClientConfig.kt
@@ -1,0 +1,86 @@
+package no.nav.syfo.fastlege.ws.util
+
+import no.nav.syfo.client.StsClientProperties
+import org.apache.cxf.Bus
+import org.apache.cxf.binding.soap.Soap12
+import org.apache.cxf.binding.soap.SoapMessage
+import org.apache.cxf.endpoint.Client
+import org.apache.cxf.frontend.ClientProxy
+import org.apache.cxf.rt.security.SecurityConstants
+import org.apache.cxf.ws.policy.PolicyBuilder
+import org.apache.cxf.ws.policy.PolicyEngine
+import org.apache.cxf.ws.policy.attachment.reference.ReferenceResolver
+import org.apache.cxf.ws.policy.attachment.reference.RemoteReferenceResolver
+import org.apache.cxf.ws.security.trust.STSClient
+import org.apache.neethi.Policy
+import java.util.*
+
+private const val STS_PATH = "/SecurityTokenServiceProvider/"
+private const val STS_REQUEST_SAML_POLICY = "classpath:policy/requestSamlPolicy.xml"
+private const val STS_CLIENT_AUTHENTICATION_POLICY = "classpath:policy/untPolicy.xml"
+
+fun configureRequestSamlToken(
+    port: Any,
+    stsProperties: StsClientProperties,
+) {
+    val client = ClientProxy.getClient(port)
+    val stsClient = createCustomSTSClient(client.bus)
+    configureSTSClient(
+        stsClient = stsClient,
+        location = stsProperties.baseUrl + STS_PATH,
+        username = stsProperties.serviceuserUsername,
+        password = stsProperties.serviceuserPassword,
+    )
+    client.requestContext[SecurityConstants.STS_CLIENT] = stsClient
+    client.requestContext[SecurityConstants.CACHE_ISSUED_TOKEN_IN_ENDPOINT] = true
+    setEndpointPolicyReference(client, STS_REQUEST_SAML_POLICY)
+}
+
+fun createCustomSTSClient(bus: Bus): STSClient {
+    return STSClientWSTrust13and14(bus)
+}
+
+fun configureSTSClient(
+    stsClient: STSClient,
+    location: String?,
+    username: String,
+    password: String
+) {
+    stsClient.isEnableAppliesTo = false
+    stsClient.isAllowRenewing = false
+    stsClient.location = location
+    val properties = HashMap<String, Any>()
+    properties[SecurityConstants.USERNAME] = username
+    properties[SecurityConstants.PASSWORD] = password
+    stsClient.properties = properties
+    stsClient.setPolicy(STS_CLIENT_AUTHENTICATION_POLICY)
+}
+
+fun setEndpointPolicyReference(
+    client: Client,
+    uri: String
+) {
+    val policy = resolvePolicyReference(client, uri)
+    setClientEndpointPolicy(client, policy)
+}
+
+private fun resolvePolicyReference(
+    client: Client,
+    uri: String
+): Policy {
+    val policyBuilder = client.bus.getExtension(PolicyBuilder::class.java)
+    val resolver: ReferenceResolver = RemoteReferenceResolver("", policyBuilder)
+    return resolver.resolveReference(uri)
+}
+
+private fun setClientEndpointPolicy(
+    client: Client,
+    policy: Policy
+) {
+    val endpoint = client.endpoint
+    val endpointInfo = endpoint.endpointInfo
+    val policyEngine = client.bus.getExtension(PolicyEngine::class.java)
+    val message = SoapMessage(Soap12.getInstance())
+    val endpointPolicy = policyEngine.getClientEndpointPolicy(endpointInfo, null, message)
+    policyEngine.setClientEndpointPolicy(endpointInfo, endpointPolicy.updatePolicy(policy, message))
+}

--- a/src/main/kotlin/no/nav/syfo/fastlege/ws/util/STSClientWSTrust13and14.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/ws/util/STSClientWSTrust13and14.kt
@@ -1,0 +1,11 @@
+package no.nav.syfo.fastlege.ws.util
+
+import org.apache.cxf.Bus
+import org.apache.cxf.ws.security.trust.STSClient
+
+class STSClientWSTrust13and14(b: Bus) : STSClient(b) {
+
+    override fun useSecondaryParameters(): Boolean {
+        return false
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/fastlege/ws/util/WsClient.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/ws/util/WsClient.kt
@@ -1,0 +1,31 @@
+package no.nav.syfo.fastlege.ws.util
+
+import org.apache.cxf.frontend.ClientProxy
+import org.apache.cxf.jaxws.JaxWsProxyFactoryBean
+import org.apache.cxf.message.Message
+import org.apache.cxf.phase.PhaseInterceptor
+import org.apache.cxf.ws.addressing.WSAddressingFeature
+import java.util.*
+import java.util.function.Consumer
+import javax.xml.ws.BindingProvider
+import javax.xml.ws.handler.Handler
+
+class WsClient<T> {
+    fun createPort(
+        serviceUrl: String,
+        portType: Class<*>,
+        handlers: List<Handler<*>>,
+        vararg interceptors: PhaseInterceptor<out Message>
+    ): T {
+        val jaxWsProxyFactoryBean = JaxWsProxyFactoryBean()
+        jaxWsProxyFactoryBean.serviceClass = portType
+        jaxWsProxyFactoryBean.address = Objects.requireNonNull(serviceUrl)
+        jaxWsProxyFactoryBean.features.add(WSAddressingFeature())
+        val port = jaxWsProxyFactoryBean.create() as T
+        (port as BindingProvider).binding.handlerChain = handlers
+        val client = ClientProxy.getClient(port)
+        Arrays.stream(interceptors)
+            .forEach(Consumer { e: PhaseInterceptor<out Message?>? -> client.outInterceptors.add(e) })
+        return port
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/util/PipelineUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/PipelineUtil.kt
@@ -20,6 +20,10 @@ fun PipelineContext<out Unit, ApplicationCall>.getBearerHeader(): String? {
     return this.call.request.headers[HttpHeaders.Authorization]?.removePrefix("Bearer ")
 }
 
+fun PipelineContext<out Unit, ApplicationCall>.getHeader(header: String): String? {
+    return this.call.request.headers[header]
+}
+
 suspend fun PipelineContext<out Unit, ApplicationCall>.proxyRequestHandler(
     authorizedApplicationNameList: List<String>,
     apiConsumerAccessService: APIConsumerAccessService,

--- a/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
@@ -4,6 +4,7 @@ import java.util.*
 
 const val NAV_CALL_ID_HEADER = "Nav-Call-Id"
 const val NAV_CONSUMER_TOKEN_HEADER = "Nav-Consumer-Token"
+const val NAV_PERSONIDENT_HEADER = "nav-personident"
 
 fun bearerHeader(token: String) = "Bearer $token"
 

--- a/src/main/resources/policy/requestSamlPolicy.xml
+++ b/src/main/resources/policy/requestSamlPolicy.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsp:Policy xmlns:wsp="http://www.w3.org/ns/ws-policy" xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702" xmlns:wst="http://docs.oasis-open.org/ws-sx/ws-trust/200512">
+    <wsp:ExactlyOne>
+        <wsp:All>
+            <sp:TransportBinding
+                    xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+                <wsp:Policy>
+                    <sp:TransportToken>
+                        <wsp:Policy>
+                            <sp:HttpsToken>
+                                <wsp:Policy/>
+                            </sp:HttpsToken>
+                        </wsp:Policy>
+                    </sp:TransportToken>
+                    <sp:AlgorithmSuite>
+                        <wsp:Policy>
+                            <sp:TripleDes />
+                        </wsp:Policy>
+                    </sp:AlgorithmSuite>
+                    <sp:Layout>
+                        <wsp:Policy>
+                            <sp:Lax />
+                        </wsp:Policy>
+                    </sp:Layout>
+                </wsp:Policy>
+            </sp:TransportBinding>
+            <sp:SupportingTokens>
+                <wsp:Policy>
+                    <sp:IssuedToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient">
+                        <sp:RequestSecurityTokenTemplate>
+                            <wst:SecondaryParameters xmlns:wst="http://docs.oasis-open.org/ws-sx/ws-trust/200512">
+                                <wst:TokenType>http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV2.0</wst:TokenType>
+                            </wst:SecondaryParameters>
+                            <wst:TokenType>http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV2.0</wst:TokenType>
+                            <wst:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/Bearer</wst:KeyType>
+                        </sp:RequestSecurityTokenTemplate>
+                        <wsp:Policy>
+                        </wsp:Policy>
+                    </sp:IssuedToken>
+                </wsp:Policy>
+            </sp:SupportingTokens>
+        </wsp:All>
+    </wsp:ExactlyOne>
+</wsp:Policy>

--- a/src/main/resources/policy/requestSamlPolicyNoTransportBinding.xml
+++ b/src/main/resources/policy/requestSamlPolicyNoTransportBinding.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsp:Policy xmlns:wsp="http://www.w3.org/ns/ws-policy" xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702" xmlns:wst="http://docs.oasis-open.org/ws-sx/ws-trust/200512">
+    <wsp:ExactlyOne>
+        <wsp:All>
+            <sp:SupportingTokens>
+                <wsp:Policy>
+                    <sp:IssuedToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient">
+                        <sp:RequestSecurityTokenTemplate>
+                            <wst:SecondaryParameters xmlns:wst="http://docs.oasis-open.org/ws-sx/ws-trust/200512">
+                                <wst:TokenType>http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV2.0</wst:TokenType>
+                            </wst:SecondaryParameters>
+                            <wst:TokenType>http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV2.0</wst:TokenType>
+                            <wst:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/Bearer</wst:KeyType>
+                        </sp:RequestSecurityTokenTemplate>
+                        <wsp:Policy>
+                        </wsp:Policy>
+                    </sp:IssuedToken>
+                </wsp:Policy>
+            </sp:SupportingTokens>
+        </wsp:All>
+    </wsp:ExactlyOne>
+</wsp:Policy>

--- a/src/main/resources/policy/untPolicy.xml
+++ b/src/main/resources/policy/untPolicy.xml
@@ -1,0 +1,17 @@
+<wsp:Policy xmlns:wsp="http://www.w3.org/ns/ws-policy"
+            xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+    <wsp:ExactlyOne>
+        <wsp:All>
+            <sp:SupportingTokens xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+                <wsp:Policy>
+                    <sp:UsernameToken
+                            sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient">
+                        <wsp:Policy>
+                            <sp:WssUsernameToken10/>
+                        </wsp:Policy>
+                    </sp:UsernameToken>
+                </wsp:Policy>
+            </sp:SupportingTokens>
+        </wsp:All>
+    </wsp:ExactlyOne>
+</wsp:Policy>

--- a/src/test/kotlin/no/nav/syfo/testhelper/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/ExternalMockEnvironment.kt
@@ -10,12 +10,16 @@ class ExternalMockEnvironment() {
     val eregMock = EregMock()
     val stsMock = STSMock()
     val dokDistMock = DokDistMock()
+    val fastlegeMock = FastlegeMock()
+    val adresseregisterMock = AdresseregisterMock()
     val syfosyketilfelleMock = SyfosyketilfelleMock()
 
     val externalApplicationMockMap = hashMapOf(
         eregMock.name to eregMock.server,
         stsMock.name to stsMock.server,
         dokDistMock.name to dokDistMock.server,
+        fastlegeMock.name to fastlegeMock.server,
+        adresseregisterMock.name to adresseregisterMock.server,
         syfosyketilfelleMock.name to syfosyketilfelleMock.server,
     )
 
@@ -23,6 +27,8 @@ class ExternalMockEnvironment() {
         eregUrl = eregMock.url,
         stsUrl = stsMock.url,
         dokdistUrl = dokDistMock.url,
+        fastlegeUrl = fastlegeMock.url,
+        adresseregisterUrl = adresseregisterMock.url,
         syfosyketilfelleUrl = syfosyketilfelleMock.url,
     )
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -10,6 +10,8 @@ fun testEnvironment(
     eregUrl: String,
     stsUrl: String,
     dokdistUrl: String,
+    fastlegeUrl: String,
+    adresseregisterUrl: String,
     syfosyketilfelleUrl: String,
 ) = Environment(
     aadAppClient = "isproxy-client-id",
@@ -20,6 +22,8 @@ fun testEnvironment(
     eregUrl = eregUrl,
     stsUrl = stsUrl,
     dokdistUrl = dokdistUrl,
+    fastlegeUrl = fastlegeUrl,
+    adresseregisterUrl = adresseregisterUrl,
     syfosyketilfelleUrl = syfosyketilfelleUrl,
 )
 

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/AdresseregisterMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/AdresseregisterMock.kt
@@ -1,0 +1,36 @@
+package no.nav.syfo.testhelper.mock
+
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import no.nav.syfo.application.api.authentication.installContentNegotiation
+import no.nav.syfo.testhelper.getRandomPort
+
+class AdresseregisterMock {
+    private val port = getRandomPort()
+    val url = "http://localhost:$port"
+
+    val name = "fastlege"
+    val server = mockAdresseregisterServer(
+        port
+    )
+
+    private fun mockAdresseregisterServer(
+        port: Int
+    ): NettyApplicationEngine {
+        return embeddedServer(
+            factory = Netty,
+            port = port
+        ) {
+            installContentNegotiation()
+            routing {
+                get() {
+                    call.respond(HttpStatusCode.OK)
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/FastlegeMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/FastlegeMock.kt
@@ -1,0 +1,36 @@
+package no.nav.syfo.testhelper.mock
+
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import no.nav.syfo.application.api.authentication.installContentNegotiation
+import no.nav.syfo.testhelper.getRandomPort
+
+class FastlegeMock {
+    private val port = getRandomPort()
+    val url = "http://localhost:$port"
+
+    val name = "fastlege"
+    val server = mockFastlegeServer(
+        port
+    )
+
+    private fun mockFastlegeServer(
+        port: Int
+    ): NettyApplicationEngine {
+        return embeddedServer(
+            factory = Netty,
+            port = port
+        ) {
+            installContentNegotiation()
+            routing {
+                get() {
+                    call.respond(HttpStatusCode.OK)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Her er et utkast til flytting av soap-tjenestene fra fastlegerest til isproxy. Formålet er å legge til rette for at fastlegerest skal kunne migreres til gcp.

Det mangler en del rundt metrics og testkode, men tenkte at det var greit med tilbakemeldinger på denne måten å gjøre det på før jeg ordner det.

Jeg har i utgangspunktet kopiert en god del kode fra fastlegerest, men har etterpå konvertert en del Java-kode til Kotlin og forsøkt å rydde opp litt og fjernet redundant/ubrukt kode relatert til disse soap-tjenestekallene. 