### PR TITLE
Remove Syfoveileder dev/prod-fss from inbound access

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -53,9 +53,6 @@ spec:
         - application: syfoveileder
           namespace: teamsykefravr
           cluster: dev-gcp
-        - application: syfoveileder
-          namespace: teamsykefravr
-          cluster: dev-fss
   azure:
     application:
       enabled: true

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -53,9 +53,6 @@ spec:
         - application: syfoperson
           namespace: teamsykefravr
           cluster: prod-fss
-        - application: syfoveileder
-          namespace: teamsykefravr
-          cluster: prod-fss
   azure:
     application:
       enabled: true

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -59,7 +59,7 @@ val testAzureAppPreAuthorizedApps = listOf(
         clientId = testSyfopersonClientId,
     ),
     PreAuthorizedClient(
-        name = "dev-fss:teamsykefravr:syfoveileder",
+        name = "dev-gcp:teamsykefravr:syfoveileder",
         clientId = testSyfoveilederClientId,
     ),
 )


### PR DESCRIPTION
Syfoveileder has been fully migrated to GCP and longer exists in FSS