### PR TITLE
Btsys proxy for padm2

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -52,6 +52,12 @@ spec:
         - application: isnarmesteleder
           namespace: teamsykefravr
           cluster: dev-gcp
+        - application: padm2
+          namespace: teamsykefravr
+          cluster: dev-fss
+        - application: padm2
+          namespace: teamsykefravr
+          cluster: dev-gcp
         - application: syfobehandlendeenhet
           namespace: teamsykefravr
           cluster: dev-gcp
@@ -84,6 +90,8 @@ spec:
       value: "production"
     - name: AXSYS_URL
       value: "https://axsys.nais.preprod.local"
+    - name: BTSYS_URL
+      value: "https://btsys.nais.preprod.local"
     - name: EREG_URL
       value: "https://modapp-q1.adeo.no"
     - name: NORG2_URL

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -52,6 +52,12 @@ spec:
         - application: isnarmesteleder
           namespace: teamsykefravr
           cluster: prod-gcp
+        - application: padm2
+          namespace: teamsykefravr
+          cluster: prod-fss
+        - application: padm2
+          namespace: teamsykefravr
+          cluster: prod-gcp
         - application: syfobehandlendeenhet
           namespace: teamsykefravr
           cluster: prod-gcp
@@ -84,6 +90,8 @@ spec:
       value: "production"
     - name: AXSYS_URL
       value: "https://axsys.nais.adeo.no"
+    - name: BTSYS_URL
+      value: "https://btsys.nais.adeo.no"
     - name: EREG_URL
       value: "https://modapp.adeo.no"
     - name: NORG2_URL

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -7,6 +7,7 @@ data class Environment(
     val aadAppClient: String = getEnvVar("AZURE_APP_CLIENT_ID"),
     val azureAppWellKnownUrl: String = getEnvVar("AZURE_APP_WELL_KNOWN_URL"),
     val azureAppPreAuthorizedApps: String = getEnvVar("AZURE_APP_PRE_AUTHORIZED_APPS"),
+    val btsysUrl: String = getEnvVar("BTSYS_URL"),
     val serviceuserUsername: String = getFileAsString("/secrets/serviceuser/isproxy/username"),
     val serviceuserPassword: String = getFileAsString("/secrets/serviceuser/isproxy/password"),
     val eregUrl: String = getEnvVar("EREG_URL"),
@@ -22,6 +23,7 @@ data class Environment(
     val isdialogmoteApplicationName: String = "isdialogmote",
     val isnarmestelederApplicationName: String = "isnarmesteleder",
     val fastlegerestApplicationName: String = "fastlegerest",
+    val padm2ApplicationName: String = "padm2",
     val syfobehandlendeenhetApplicationName: String = "syfobehandlendeenhet",
     val syfopersonApplicationName: String = "syfoperson",
     val syfoveilederApplicationName: String = "syfoveileder",
@@ -31,6 +33,9 @@ data class Environment(
     ),
     val axsysAPIAuthorizedConsumerApplicationNameList: List<String> = listOf(
         syfoveilederApplicationName,
+    ),
+    val btsysAPIAuthorizedConsumerApplicationNameList: List<String> = listOf(
+        padm2ApplicationName,
     ),
     val dokdistAPIAuthorizedConsumerApplicationNameList: List<String> = listOf(
         isdialogmoteApplicationName,

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -9,10 +9,12 @@ import no.nav.syfo.application.api.access.APIConsumerAccessService
 import no.nav.syfo.application.api.authentication.*
 import no.nav.syfo.axsys.api.registerAxsysApi
 import no.nav.syfo.axsys.client.AxsysClient
+import no.nav.syfo.btsys.client.BtsysClient
 import no.nav.syfo.client.StsClientProperties
 import no.nav.syfo.client.sts.StsClient
 import no.nav.syfo.dokdist.api.registerDokdistApi
 import no.nav.syfo.dokdist.client.DokdistClient
+import no.nav.syfo.ereg.api.registerBtsysProxyApi
 import no.nav.syfo.ereg.api.registerEregProxyApi
 import no.nav.syfo.ereg.client.EregClient
 import no.nav.syfo.fastlege.api.registerFastlegeApi
@@ -65,6 +67,11 @@ fun Application.apiModule(
         baseUrl = environment.eregUrl,
         stsClient = stsClient,
     )
+    val btsysClient = BtsysClient(
+        baseUrl = environment.btsysUrl,
+        stsClient = stsClient,
+        serviceUserName = environment.serviceuserUsername,
+    )
     val norg2Client = Norg2Client(
         baseUrl = environment.norg2Url,
     )
@@ -93,10 +100,20 @@ fun Application.apiModule(
                 authorizedApplicationNameList = environment.axsysAPIAuthorizedConsumerApplicationNameList,
                 axsysClient = axsysClient,
             )
+            registerBtsysProxyApi(
+                apiConsumerAccessService = apiConsumerAccessService,
+                authorizedApplicationNameList = environment.btsysAPIAuthorizedConsumerApplicationNameList,
+                btsysClient = btsysClient,
+            )
             registerDokdistApi(
                 apiConsumerAccessService = apiConsumerAccessService,
                 authorizedApplicationNameList = environment.dokdistAPIAuthorizedConsumerApplicationNameList,
                 dokdistClient = dokdistClient,
+            )
+            registerEregProxyApi(
+                apiConsumerAccessService = apiConsumerAccessService,
+                authorizedApplicationNameList = environment.eregAPIAuthorizedConsumerApplicationNameList,
+                eregClient = eregClient,
             )
             registerFastlegeApi(
                 apiConsumerAccessService = apiConsumerAccessService,
@@ -107,11 +124,6 @@ fun Application.apiModule(
                 apiConsumerAccessService = apiConsumerAccessService,
                 authorizedApplicationNameList = environment.fastlegepraksisAPIAuthorizedConsumerApplicationNameList,
                 adresseregisterClient = adresseregisterClient,
-            )
-            registerEregProxyApi(
-                apiConsumerAccessService = apiConsumerAccessService,
-                authorizedApplicationNameList = environment.eregAPIAuthorizedConsumerApplicationNameList,
-                eregClient = eregClient,
             )
             registerNorg2Api(
                 apiConsumerAccessService = apiConsumerAccessService,

--- a/src/main/kotlin/no/nav/syfo/btsys/BtsysMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/btsys/BtsysMetric.kt
@@ -1,0 +1,19 @@
+package no.nav.syfo.btsys
+
+import io.micrometer.core.instrument.Counter
+import no.nav.syfo.metric.METRICS_NS
+import no.nav.syfo.metric.METRICS_REGISTRY
+
+const val CALL_BTSYS_SUSPENSJON_BASE = "${METRICS_NS}_call_btsys_suspensjon"
+const val CALL_BTSYS_SUSPENSJON_SUCCESS = "${CALL_BTSYS_SUSPENSJON_BASE}_success_count"
+const val CALL_BTSYS_SUSPENSJON_FAIL = "${CALL_BTSYS_SUSPENSJON_BASE}_fail_count"
+
+val COUNT_CALL_BTSYS_SUSPENSJON_SUCCESS: Counter = Counter
+    .builder(CALL_BTSYS_SUSPENSJON_SUCCESS)
+    .description("Counts the number of successful calls to btsys - suspensjon")
+    .register(METRICS_REGISTRY)
+
+val COUNT_CALL_BTSYS_SUSPENSJON_FAIL: Counter = Counter
+    .builder(CALL_BTSYS_SUSPENSJON_FAIL)
+    .description("Counts the number of failed calls to btsys - suspensjon")
+    .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/btsys/api/BtsysProxyApi.kt
+++ b/src/main/kotlin/no/nav/syfo/btsys/api/BtsysProxyApi.kt
@@ -1,0 +1,34 @@
+package no.nav.syfo.ereg.api
+
+import io.ktor.application.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import no.nav.syfo.application.api.access.APIConsumerAccessService
+import no.nav.syfo.btsys.client.BtsysClient
+import no.nav.syfo.util.*
+
+const val btsysProxyBasePath = "/api/v1/btsys"
+const val btsysProxySuspendertPath = "/suspensjon/status"
+
+fun Route.registerBtsysProxyApi(
+    apiConsumerAccessService: APIConsumerAccessService,
+    authorizedApplicationNameList: List<String>,
+    btsysClient: BtsysClient,
+) {
+    route(btsysProxyBasePath) {
+        get(btsysProxySuspendertPath) {
+            proxyRequestHandler(
+                apiConsumerAccessService = apiConsumerAccessService,
+                authorizedApplicationNameList = authorizedApplicationNameList,
+                proxyServiceName = "Btsys",
+            ) {
+                val personIdent = getHeader(NAV_PERSONIDENT_HEADER)
+                    ?: throw RuntimeException("Btsys proxy: PersonIdent missing in request")
+                val oppslagsdato = call.parameters["oppslagsdato"]
+                    ?: throw RuntimeException("Btsys proxy: oppslagsdato param missing in request")
+                val suspendert = btsysClient.suspendert(personIdent, oppslagsdato, getCallId())
+                call.respond(suspendert)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/btsys/client/BtsysClient.kt
+++ b/src/main/kotlin/no/nav/syfo/btsys/client/BtsysClient.kt
@@ -1,0 +1,51 @@
+package no.nav.syfo.btsys.client
+
+import io.ktor.client.features.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import no.nav.syfo.btsys.COUNT_CALL_BTSYS_SUSPENSJON_FAIL
+import no.nav.syfo.btsys.COUNT_CALL_BTSYS_SUSPENSJON_SUCCESS
+import no.nav.syfo.client.httpClientDefault
+import no.nav.syfo.client.sts.StsClient
+import no.nav.syfo.util.*
+
+class BtsysClient(
+    val baseUrl: String,
+    val stsClient: StsClient,
+    val serviceUserName: String,
+) {
+    private val httpClient = httpClientDefault()
+
+    private val btsysUrl: String = "$baseUrl$BTSYS_PATH"
+
+    suspend fun suspendert(
+        personIdent: String,
+        oppslagsdato: String,
+        callId: String,
+    ): Suspendert {
+        val stsToken = stsClient.token()
+        try {
+            val response: Suspendert = httpClient.get(btsysUrl) {
+                accept(ContentType.Application.Json)
+                headers {
+                    append(NAV_CALL_ID_HEADER, callId)
+                    append(NAV_CONSUMER_ID_HEADER, serviceUserName)
+                    append(NAV_PERSONIDENT_HEADER, personIdent)
+                    append(HttpHeaders.Authorization, bearerHeader(stsToken))
+                }
+                parameter("oppslagsdato", oppslagsdato)
+            }
+            COUNT_CALL_BTSYS_SUSPENSJON_SUCCESS.increment()
+            return response
+        } catch (responseException: ResponseException) {
+            COUNT_CALL_BTSYS_SUSPENSJON_FAIL.increment()
+            throw responseException
+        }
+    }
+
+    data class Suspendert(val suspendert: Boolean)
+
+    companion object {
+        const val BTSYS_PATH = "/api/v1/suspensjon/status"
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/btsys/api/BtsysApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/btsys/api/BtsysApiSpek.kt
@@ -1,0 +1,97 @@
+package no.nav.syfo.btsys.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.ktor.http.*
+import io.ktor.http.HttpHeaders.Authorization
+import io.ktor.server.testing.*
+import no.nav.syfo.btsys.client.BtsysClient
+import no.nav.syfo.ereg.api.*
+import no.nav.syfo.testhelper.*
+import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
+import no.nav.syfo.util.bearerHeader
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+class BtsysApiSpek : Spek({
+    val objectMapper: ObjectMapper = apiConsumerObjectMapper()
+
+    describe(BtsysApiSpek::class.java.simpleName) {
+
+        with(TestApplicationEngine()) {
+            start()
+
+            val externalMockEnvironment = ExternalMockEnvironment()
+
+            beforeGroup {
+                externalMockEnvironment.startExternalMocks()
+            }
+
+            afterGroup {
+                externalMockEnvironment.stopExternalMocks()
+            }
+
+            application.testApiModule(
+                externalMockEnvironment = externalMockEnvironment,
+            )
+
+            val today = DateTimeFormatter.ISO_DATE.format(LocalDateTime.now())
+            val urlSuspensjon = "$btsysProxyBasePath$btsysProxySuspendertPath?oppslagsdato=$today"
+
+            describe("Get suspensjon") {
+                val validToken = generateJWT(
+                    externalMockEnvironment.environment.aadAppClient,
+                    externalMockEnvironment.wellKnown.issuer,
+                    testPadm2ClientId,
+                )
+
+                describe("Happy path") {
+
+                    it("should return OK if request is successful") {
+                        with(
+                            handleRequest(HttpMethod.Get, urlSuspensjon) {
+                                addHeader(Authorization, bearerHeader(validToken))
+                                addHeader(NAV_PERSONIDENT_HEADER, "12345678901")
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.OK
+                            val suspensjonResponse = objectMapper.readValue<BtsysClient.Suspendert>(response.content!!)
+                            suspensjonResponse.suspendert shouldBeEqualTo false
+                        }
+                    }
+                }
+                describe("Unhappy paths") {
+                    it("should return status Unauthorized if no token is supplied") {
+                        with(
+                            handleRequest(HttpMethod.Get, urlSuspensjon) {
+                                addHeader(NAV_PERSONIDENT_HEADER, "12345678901")
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.Unauthorized
+                        }
+                    }
+
+                    it("should return status Forbidden if unauthorized AZP is supplied") {
+                        val validTokenUnauthorizedAZP = generateJWT(
+                            externalMockEnvironment.environment.aadAppClient,
+                            externalMockEnvironment.wellKnown.issuer,
+                            testSyfopersonClientId,
+                        )
+
+                        with(
+                            handleRequest(HttpMethod.Get, urlSuspensjon) {
+                                addHeader(Authorization, bearerHeader(validTokenUnauthorizedAZP))
+                                addHeader(NAV_PERSONIDENT_HEADER, "12345678901")
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.Forbidden
+                        }
+                    }
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/testhelper/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/ExternalMockEnvironment.kt
@@ -9,6 +9,7 @@ class ExternalMockEnvironment() {
     val wellKnown = wellKnownMock()
     val axsysMock = AxsysMock()
     val eregMock = EregMock()
+    val btsysMock = BtsysMock()
     val stsMock = STSMock()
     val dokDistMock = DokDistMock()
     val fastlegeMock = FastlegeMock()
@@ -18,6 +19,7 @@ class ExternalMockEnvironment() {
 
     val externalApplicationMockMap = hashMapOf(
         axsysMock.name to axsysMock.server,
+        btsysMock.name to btsysMock.server,
         eregMock.name to eregMock.server,
         stsMock.name to stsMock.server,
         dokDistMock.name to dokDistMock.server,
@@ -27,6 +29,7 @@ class ExternalMockEnvironment() {
 
     val environment = testEnvironment(
         axsysUrl = axsysMock.url,
+        btsysUrl = btsysMock.url,
         eregUrl = eregMock.url,
         stsUrl = stsMock.url,
         stsSamlUrl = stsMock.url,

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -8,6 +8,7 @@ import java.net.ServerSocket
 
 fun testEnvironment(
     axsysUrl: String,
+    btsysUrl: String,
     eregUrl: String,
     stsUrl: String,
     stsSamlUrl: String,
@@ -21,6 +22,7 @@ fun testEnvironment(
     serviceuserUsername = "user",
     serviceuserPassword = "password",
     axsysUrl = axsysUrl,
+    btsysUrl = btsysUrl,
     eregUrl = eregUrl,
     stsUrl = stsUrl,
     stsSamlUrl = stsSamlUrl,
@@ -43,6 +45,7 @@ fun getRandomPort() = ServerSocket(0).use {
 const val testFastlegerestClientId = "fastlegerest-client-id"
 const val testIsdialogmoteClientId = "isdialogmote-client-id"
 const val testIsnarmestelederClientId = "isnarmesteleder-client-id"
+const val testPadm2ClientId = "padm2-client-id"
 const val testSyfobehandlendeenhetClientId = "syfobehandlendeenhet-client-id"
 const val testSyfopersonClientId = "syfoperson-client-id"
 const val testSyfoveilederClientId = "syfoveileder-client-id"
@@ -55,6 +58,10 @@ val testAzureAppPreAuthorizedApps = listOf(
     PreAuthorizedClient(
         name = "dev-gcp:teamsykefravr:isnarmesteleder",
         clientId = testIsnarmestelederClientId,
+    ),
+    PreAuthorizedClient(
+        name = "dev-gcp:teamsykefravr:padm2",
+        clientId = testPadm2ClientId,
     ),
     PreAuthorizedClient(
         name = "dev-gcp:teamsykefravr:syfobehandlendeenhet",

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/BtsysMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/BtsysMock.kt
@@ -1,0 +1,39 @@
+package no.nav.syfo.testhelper.mock
+
+import io.ktor.application.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import no.nav.syfo.application.api.authentication.installContentNegotiation
+import no.nav.syfo.btsys.client.BtsysClient
+import no.nav.syfo.testhelper.getRandomPort
+
+fun generateResponse(value: Boolean) =
+    BtsysClient.Suspendert(value)
+
+class BtsysMock {
+    private val port = getRandomPort()
+    val url = "http://localhost:$port"
+
+    val name = "btsys"
+    val server = mockBtsysServer(
+        port
+    )
+
+    private fun mockBtsysServer(
+        port: Int
+    ): NettyApplicationEngine {
+        return embeddedServer(
+            factory = Netty,
+            port = port
+        ) {
+            installContentNegotiation()
+            routing {
+                get(BtsysClient.BTSYS_PATH) {
+                    call.respond(generateResponse(false))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
For å kunne kjøre padm2 på gcp må vi aksessere btsys via isproxy.